### PR TITLE
increase number of images returned by catalog

### DIFF
--- a/docker_registry_util/client.py
+++ b/docker_registry_util/client.py
@@ -64,8 +64,8 @@ class DockerRegistryClient(object):
     def ping(self):
         return self._request('GET', '')
 
-    def get_catalog(self):
-        return self._request('GET', '_catalog')
+    def get_catalog(self, max_results):
+        return self._request('GET', '_catalog', params={'n' : max_results})
 
     def get_tags(self, name):
         return self._request('GET', name, 'tags', 'list')

--- a/docker_registry_util/query.py
+++ b/docker_registry_util/query.py
@@ -118,6 +118,7 @@ class DockerRegistryQuery(object):
         self._client = client
         self._cache = ImageDigestCache()
         self._initialized = False
+        self.max_results = 500
 
     @property
     def client(self):
@@ -128,7 +129,7 @@ class DockerRegistryQuery(object):
         if self._initialized:
             log.info("Clearing.")
             self._cache.reset()
-        repos = self._client.get_catalog().json()['repositories']
+        repos = self._client.get_catalog(max_results=self.max_results).json()['repositories']
         log.info("Found %s repositories.", len(repos))
         for repo in repos:
             log.info("Checking repository '%s'.", repo)


### PR DESCRIPTION
V2 registry uses pagination on the `_catalog` endpoint.
By default it results ~50 repositories.
It can be controlled by query parameter `n`. Such as `docker-registry..com/v2/_catalog?n=1000`.
In the existing code this seems ignored at all and the list of *all* images is always shorter than actual when there are lots of them.
This should be probably some configuration value. So far I have added `n` to the HTTP request and increased default to 500.