### PR TITLE
print tags for digests for query-tags and remove-tags commands

### DIFF
--- a/docker_registry_util/cli.py
+++ b/docker_registry_util/cli.py
@@ -170,8 +170,9 @@ def query_repos(query):
 def query_tags(query):
     repo_len = max(map(len, args.repo))
     result = query.select_tags(args.repo, **_get_tag_args())
-    for repo, digest in result:
-        print('{0:{1}}  {2}'.format(repo, repo_len, digest))
+    sorted_by_tags_result = sorted(result, key=lambda x: x[2])
+    for repo, digest, tags in sorted_by_tags_result:
+        print('{0:{1}} {2} {3}'.format(repo, repo_len, digest, tags))
     _show_count('selected digests', result)
 
 

--- a/docker_registry_util/query.py
+++ b/docker_registry_util/query.py
@@ -122,12 +122,12 @@ class DockerRegistryQuery(object):
     def client(self):
         return self._client
 
-    def refresh(self):
+    def refresh(self, repos=None):
         log.info("Initializing cache.")
         if self._initialized:
             log.info("Clearing.")
             self._cache.reset()
-        repos = self._client.get_catalog().json()['repositories']
+        repos = self._client.get_catalog().json()['repositories'] if not repos else _str_or_list(repos)
         log.info("Found %s repositories.", len(repos))
         for repo in repos:
             log.info("Checking repository '%s'.", repo)
@@ -269,7 +269,7 @@ class DockerRegistryQuery(object):
             return result
 
         if not self._initialized:
-            self.refresh()
+            self.refresh(repos)
         included_filter = _generate_tag_funcs(tags)
         excluded_filter = _generate_tag_funcs(exclude_tags)
         tag_sets = dict()
@@ -316,7 +316,7 @@ class DockerRegistryQuery(object):
         :rtype: list[(str, str)]
         """
         if not self._initialized:
-            self.refresh()
+            self.refresh(repos)
         if repos:
             repo_list = _str_or_list(repos)
         else:

--- a/docker_registry_util/remover.py
+++ b/docker_registry_util/remover.py
@@ -52,10 +52,10 @@ class DockerRegistryRemover(object):
         client = self._query.client
         cache = self._query.cache
         tag_digests = self._query.select_tags(repos, tags, **kwargs)
-        for name, digest in tag_digests:
-            log.info("Removing digest %s.", digest)
+        for name, digest, tags in tag_digests:
+            log.info("Removing digest %s (tags: %s).", digest, tags)
             client.delete_manifest(name, digest.as_sha256())
-        digests_only = [i[1] for i in tag_digests]
+        digests_only = [digest for name, digest, tags in tag_digests]
         cache.remove_digests(digests_only)
         log.info("Deleted %s digests.", len(tag_digests))
         return tag_digests

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -40,16 +40,16 @@ class QueryTest(unittest.TestCase):
 
     def test_independent_tag_selection(self):
         q = self.query.select_tags
-        self.assertItemsEqual(q('a', ('<1.2.0', 'latest')), [('a', D_A1)])
-        self.assertItemsEqual(q('a', (_ALL_TAGS, )), [('a', D_A1), ('a', D_A2)])
-        self.assertItemsEqual(q('c', ('>=1.1.0', 'testing')), [('c', D_C)])
+        self.assertItemsEqual(q('a', ('<1.2.0', 'latest')), [('a', D_A1, ['1.1.0', 'latest'])])
+        self.assertItemsEqual(q('a', (_ALL_TAGS, )), [('a', D_A1, ['1.1.0', 'latest']), ('a', D_A2, ['1.2.0', 'testing', 'extra'])])
+        self.assertItemsEqual(q('c', ('>=1.1.0', 'testing')), [('c', D_C, ['1.1.0', 'testing'])])
 
     def test_intersecting_tag_selection(self):
         q = self.query.select_tags
-        self.assertItemsEqual(q('a', ('<=1.2.0', 'latest')), [('a', D_A1)])
-        self.assertItemsEqual(q(['b', 'c'], _ALL_TAGS), [('b', D_BC), ('c', D_C)])
-        self.assertItemsEqual(q(['b', 'c'], ('1.0.0', 'latest')), [('b', D_BC)])
-        self.assertItemsEqual(q('c', _ALL_TAGS, raise_intersecting_repo=False), [('c', D_C)])
+        self.assertItemsEqual(q('a', ('<=1.2.0', 'latest')), [('a', D_A1, ['1.1.0', 'latest'])])
+        self.assertItemsEqual(q(['b', 'c'], _ALL_TAGS), [('b', D_BC, ['1.0.0', 'latest']), ('c', D_C, ['1.1.0', 'testing'])])
+        self.assertItemsEqual(q(['b', 'c'], ('1.0.0', 'latest')), [('b', D_BC, ['1.0.0', 'latest'])])
+        self.assertItemsEqual(q('c', _ALL_TAGS, raise_intersecting_repo=False), [('c', D_C, ['1.1.0', 'testing'])])
         with self.assertRaises(IntersectionError) as ie1:
             q('b', _ALL_TAGS)
         ce1 = ie1.exception
@@ -68,5 +68,5 @@ class QueryTest(unittest.TestCase):
 
     def test_tag_selection_with_exclusion(self):
         q = self.query.select_tags
-        self.assertItemsEqual(q('a', _ALL_TAGS, 'latest'), [('a', D_A2)])
-        self.assertItemsEqual(q(['b', 'c'], _ALL_TAGS, ['testing']), [('b', D_BC)])
+        self.assertItemsEqual(q('a', _ALL_TAGS, 'latest'), [('a', D_A2, ['1.2.0', 'testing', 'extra'])])
+        self.assertItemsEqual(q(['b', 'c'], _ALL_TAGS, ['testing']), [('b', D_BC, ['1.0.0', 'latest'])])


### PR DESCRIPTION
Print tags for query-tags and remove-tags commands

example:
```
dregutil query-tags -r myrepo -re .*
myrepo sha256:08c5851c58605de87818a417ad20a3bbe03dc249526c3f8045b2bb8f1140e4c7 ['0.0.0']
myrepo sha256:f1cfd5fa6a17517baee325f5764801d3161ed84d6de7080d64e0e1a63d430ebc ['0.0.0-master']
myrepo sha256:839025b393fd35866dc1ba2bc2f081c6c148e1ed6bc52326ce0a6423ead3bd85 ['0.0.0-review', '0.0.0-reviewfinish']
myrepo sha256:deef83c553c8080b835de878f295bb6adfbc143b22ab2026892a33009f89cdc0 ['0.1.0-master']
```

